### PR TITLE
Removed unnecessary brackets from lambda. This change allows the South American countries to be flagged.

### DIFF
--- a/code/03_01_columns.py
+++ b/code/03_01_columns.py
@@ -66,8 +66,8 @@ pg['is_sa'] = pg['team'].apply(is_south_america)
 
 pg[['name', 'team', 'is_sa']].sample(5)
 
-pg['is_sa_alternate'] = pg['team'].apply(lambda x: x in [
-    ['Brazil', 'Uruguay', 'Colombia', 'Argentina', 'Costa Rica', 'Peru']])
+pg['is_sa_alternate'] = pg['team'].apply(lambda x: x in 
+    ['Brazil', 'Uruguay', 'Colombia', 'Argentina', 'Costa Rica', 'Peru'])
 
 # Dropping Columns
 pg.drop('is_sa_alternate', axis=1, inplace=True)


### PR DESCRIPTION
Removed unnecessary brackets from lambda. This change allows the South American countries to be flagged.

To test this, run the original command:
```python
pg['is_sa_alternate'] = pg['team'].apply(lambda x: x in [['Brazil', 'Uruguay', 'Colombia', 'Argentina', 'Costa Rica', 'Peru']])
```
Then execute:
```python
pm[["team", "is_sa_alternate"]].sample(10)
```
You'll receive something along the lines of:
| |team|is_sa_alternate
---|---|---
533|Nigeria|False
848|Korea Republic|False
1611|Croatia|False
522|Nigeria|False
91|Uruguay|**False**

Note that Uruguay is not flagged.

Executing the updated command will result in an output similar to the one below.
| |team|is_sa_alternate
---|---|---
1358|Brazil|**True**
1511|Croatia|False
1179|Poland|False
907|Belgium|False
1242|Uruguay|**True**

Note that Brazil and Uruguay are both flagged with the updated command.
